### PR TITLE
Week 12 P1: Add ServiceSecurityGroup to CrdCluster stack

### DIFF
--- a/aws/cfn/cluster/config.toml.example
+++ b/aws/cfn/cluster/config.toml.example
@@ -1,0 +1,10 @@
+[deploy]
+bucket = '<your-cfn-artifacts-bucket-name>'
+region = '<your-aws-region>'
+stack_name = 'CrdCluster'
+
+[parameters]
+NetworkingStack = 'CrdNet'
+CertificateArn = '<your-acm-certificate-arn>'
+FrontendPort = '3000'
+BackendPort = '4567'

--- a/aws/cfn/cluster/template.yaml
+++ b/aws/cfn/cluster/template.yaml
@@ -201,6 +201,26 @@ Resources:
       VpcId:
         Fn::ImportValue:
           !Sub "${NetworkingStack}VpcId"
+  ServiceSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    # https://docs.aws.amazon.com/AWSCloudFormationGuide/latest/UserGuide/aws-resource-ec2-securitygroup.html
+    Properties:
+      GroupName: !Sub "${AWS::StackName}ServiceSG"
+      GroupDescription: SG for Cruddur Fargate service tasks - allows ingress from ALB SG on container ports
+      VpcId:
+        Fn::ImportValue:
+          !Sub "${NetworkingStack}VpcId"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref BackendPort
+          ToPort: !Ref BackendPort
+          SourceSecurityGroupId: !GetAtt ALBSecurityGroup.GroupId
+          Description: ALB to backend Fargate tasks on container port (NOT ALB listener port 80)
+        - IpProtocol: tcp
+          FromPort: !Ref FrontendPort
+          ToPort: !Ref FrontendPort
+          SourceSecurityGroupId: !GetAtt ALBSecurityGroup.GroupId
+          Description: ALB to frontend Fargate tasks on container port        
 Outputs:
   ClusterName:
     Description: Cluster name
@@ -231,3 +251,8 @@ Outputs:
     Value: !Ref FrontendTG
     Export:
       Name: !Sub "${AWS::StackName}FrontendTGArn"
+  ServiceSecurityGroup:
+    Description: Service security group ID for Fargate tasks
+    Value: !GetAtt ServiceSecurityGroup.GroupId
+    Export:
+      Name: !Sub "${AWS::StackName}ServiceSGId"

--- a/aws/cfn/cluster/template.yaml
+++ b/aws/cfn/cluster/template.yaml
@@ -1,0 +1,233 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: |
+  The networking and compute services for our Cruddur application.
+  - ECS Fargate cluster with Container Insights
+  - Application Load Balancer with HTTPS listener and HTTP-to-HTTPS redirect
+  - HTTPS listener default action: forward to frontend target group
+  - HTTPS listener rule: forward api.* host header to backend target group
+  - Backend target group (port 4567)
+  - Frontend target group (port 3000)
+  - ALB security group (allow 443 and 80 from anywhere)
+
+Parameters:
+  NetworkingStack:
+    Type: String
+    Description: The networking stack to import VpcId and PublicSubnetIds from
+    Default: CrdNet
+
+  CertificateArn:
+    Type: String
+    Description: ACM certificate ARN for HTTPS listener
+
+  FrontendPort:
+    Type: Number
+    Default: 3000
+
+  BackendPort:
+    Type: Number
+    Default: 4567
+
+  HealthCheckIntervalSeconds:
+    Type: Number
+    Default: 15
+
+  HealthCheckTimeoutSeconds:
+    Type: Number
+    Default: 5
+
+  HealthyThresholdCount:
+    Type: Number
+    Default: 2
+
+  UnhealthyThresholdCount:
+    Type: Number
+    Default: 2
+Resources:
+
+  FargateCluster:
+    Type: AWS::ECS::Cluster
+    # https://docs.aws.amazon.com/AWSCloudFormationGuide/latest/UserGuide/aws-resource-ecs-cluster.html
+    Properties:
+      ClusterName: !Sub "${AWS::StackName}FargateCluster"
+      CapacityProviders:
+        - FARGATE
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+      Configuration:
+        ExecuteCommandConfiguration:
+          Logging: DEFAULT
+      ServiceConnectDefaults:
+        Namespace: cruddur
+      Tags:
+        - Key: Name
+          Value: CruddurCluster
+
+  ALBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    # https://docs.aws.amazon.com/AWSCloudFormationGuide/latest/UserGuide/aws-resource-ec2-securitygroup.html
+    Properties:
+      GroupName: !Sub "${AWS::StackName}AlbSG"
+      GroupDescription: Public-facing SG for the Cruddur ALB
+      VpcId:
+        Fn::ImportValue:
+          !Sub "${NetworkingStack}VpcId"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+          Description: INTERNET HTTPS
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+          Description: INTERNET HTTP
+
+  ALB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    # https://docs.aws.amazon.com/AWSCloudFormationGuide/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html
+    Properties:
+      Name: !Sub "${AWS::StackName}ALB"
+      Type: application
+      Scheme: internet-facing
+      IpAddressType: ipv4
+      LoadBalancerAttributes:
+        - Key: routing.http2.enabled
+          Value: 'true'
+        - Key: routing.http.preserve_host_header.enabled
+          Value: 'true'
+        - Key: deletion_protection.enabled
+          Value: 'false'
+        - Key: load_balancing.cross_zone.enabled
+          Value: 'true'
+      SecurityGroups:
+        - !GetAtt ALBSecurityGroup.GroupId
+      Subnets:
+        Fn::Split:
+          - ","
+          - Fn::ImportValue: !Sub "${NetworkingStack}PublicSubnetIds"
+  HTTPSListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    # https://docs.aws.amazon.com/AWSCloudFormationGuide/latest/UserGuide/aws-resource-elasticloadbalancingv2-listener.html
+    Properties:
+      LoadBalancerArn: !Ref ALB
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref FrontendTG
+
+  HTTPListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    # https://docs.aws.amazon.com/AWSCloudFormationGuide/latest/UserGuide/aws-resource-elasticloadbalancingv2-listener.html
+    Properties:
+      LoadBalancerArn: !Ref ALB
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Protocol: HTTPS
+            Port: '443'
+            Host: '#{host}'
+            Path: '/#{path}'
+            Query: '#{query}'
+            StatusCode: HTTP_301
+
+  ApiALBListenerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    # https://docs.aws.amazon.com/AWSCloudFormationGuide/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenerrule.html
+    Properties:
+      ListenerArn: !Ref HTTPSListener
+      Priority: 1
+      Conditions:
+        - Field: host-header
+          HostHeaderConfig:
+            Values:
+              - api.fentoncruddur.com
+      Actions:
+        - Type: forward
+          TargetGroupArn: !Ref BackendTG
+  FrontendTG:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    # https://docs.aws.amazon.com/AWSCloudFormationGuide/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html
+    Properties:
+      Name: !Sub "${AWS::StackName}FrontendTG"
+      Port: !Ref FrontendPort
+      Protocol: HTTP
+      ProtocolVersion: HTTP2
+      HealthCheckEnabled: true
+      HealthCheckProtocol: HTTP
+      HealthCheckPort: !Sub "${FrontendPort}"
+      HealthCheckPath: "/"
+      Matcher:
+        HttpCode: '200'
+      HealthCheckIntervalSeconds: !Ref HealthCheckIntervalSeconds
+      HealthCheckTimeoutSeconds: !Ref HealthCheckTimeoutSeconds
+      HealthyThresholdCount: !Ref HealthyThresholdCount
+      UnhealthyThresholdCount: !Ref UnhealthyThresholdCount
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: '0'
+      VpcId:
+        Fn::ImportValue:
+          !Sub "${NetworkingStack}VpcId"
+
+  BackendTG:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    # https://docs.aws.amazon.com/AWSCloudFormationGuide/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html
+    Properties:
+      Name: !Sub "${AWS::StackName}BackendTG"
+      Port: !Ref BackendPort
+      Protocol: HTTP
+      ProtocolVersion: HTTP2
+      HealthCheckEnabled: true
+      HealthCheckProtocol: HTTP
+      HealthCheckPort: !Sub "${BackendPort}"
+      HealthCheckPath: "/api/health-check"
+      Matcher:
+        HttpCode: '200'
+      HealthCheckIntervalSeconds: !Ref HealthCheckIntervalSeconds
+      HealthCheckTimeoutSeconds: !Ref HealthCheckTimeoutSeconds
+      HealthyThresholdCount: !Ref HealthyThresholdCount
+      UnhealthyThresholdCount: !Ref UnhealthyThresholdCount
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: '0'
+      VpcId:
+        Fn::ImportValue:
+          !Sub "${NetworkingStack}VpcId"
+Outputs:
+  ClusterName:
+    Description: Cluster name
+    Value: !Ref FargateCluster
+    Export:
+      Name: !Sub "${AWS::StackName}ClusterName"
+
+  ALBSecurityGroup:
+    Description: ALB security group ID
+    Value: !GetAtt ALBSecurityGroup.GroupId
+    Export:
+      Name: !Sub "${AWS::StackName}ALBSecurityGroupId"
+
+  ALBListener:
+    Description: HTTPS listener ARN
+    Value: !Ref HTTPSListener
+    Export:
+      Name: !Sub "${AWS::StackName}ALBListenerArn"
+
+  BackendTG:
+    Description: Backend target group ARN
+    Value: !Ref BackendTG
+    Export:
+      Name: !Sub "${AWS::StackName}BackendTGArn"
+
+  FrontendTG:
+    Description: Frontend target group ARN
+    Value: !Ref FrontendTG
+    Export:
+      Name: !Sub "${AWS::StackName}FrontendTGArn"

--- a/bin/cfn/cluster-deploy
+++ b/bin/cfn/cluster-deploy
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+CFN_PATH="aws/cfn/cluster/template.yaml"
+CONFIG_PATH="aws/cfn/cluster/config.toml"
+
+BUCKET=$(cfn-toml key deploy.bucket -t $CONFIG_PATH)
+REGION=$(cfn-toml key deploy.region -t $CONFIG_PATH)
+STACK_NAME=$(cfn-toml key deploy.stack_name -t $CONFIG_PATH)
+PARAMETERS=$(cfn-toml params v2 -t $CONFIG_PATH)
+
+# Validate the template syntax before doing anything
+cfn-lint $CFN_PATH
+
+# Deploy the stack with a change set for review
+aws cloudformation deploy \
+  --stack-name $STACK_NAME \
+  --s3-bucket $BUCKET \
+  --region $REGION \
+  --template-file $CFN_PATH \
+  --parameter-overrides $PARAMETERS \
+  --no-execute-changeset \
+  --tags group=cruddur-cluster \
+  --capabilities CAPABILITY_NAMED_IAM

--- a/journal/week10.md
+++ b/journal/week10.md
@@ -1,1 +1,203 @@
 # Week 10 — CloudFormation Part 1
+
+## What I Set Out To Do
+
+This week marked a major shift in how I manage my Cruddur infrastructure. For the last several weeks/months, every AWS resource I touched — VPC, ECS cluster, ALB, RDS, IAM roles — was created either through the AWS Console (by clicking through screens) or through a bash script that called the AWS CLI imperatively. That works, but it leaves no version-controlled record of what the infrastructure actually looks like. If someone asked me "what does your network look like today?", my only honest answer would be "let me log into the Console and check."
+
+Week 10 was where I started fixing that. The goal was to begin a layered migration of my entire infrastructure into AWS CloudFormation — declarative YAML templates that describe the desired state of my AWS account, version-controlled in my GitHub repo, and reproducible from a single command. I started with the foundational layer: networking. Everything else (compute, load balancing, database) sits on top of the network, so this was the right place to begin.
+
+## The Stack I Built — CrdNet
+
+I built a single CloudFormation stack called `CrdNet`. It defines the network foundation for the entire Cruddur application:
+
+- **A new VPC** with CIDR `10.0.0.0/16` (65,536 private IP addresses to work with)
+- **An Internet Gateway** so resources in the VPC can reach the public internet
+- **Three public subnets** spread across `us-east-1a`, `us-east-1b`, and `us-east-1c` (CIDRs `10.0.0.0/24`, `10.0.1.0/24`, `10.0.2.0/24`)
+- **Three private subnets** also spread across the same three Availability Zones (CIDRs `10.0.4.0/24`, `10.0.5.0/24`, `10.0.6.0/24`)
+- **A public route table** with a `0.0.0.0/0` route pointing to the Internet Gateway, associated with all three public subnets
+- **A private route table** with only the local VPC route, associated with all three private subnets
+- **Five cross-stack exports** (`CrdNetVpcId`, `CrdNetVpcCidrBlock`, `CrdNetPublicSubnetIds`, `CrdNetPrivateSubnetIds`, `CrdNetAvailabilityZones`) — these are values that future stacks (cluster, database, services) can import via `!ImportValue` without having to know the underlying physical IDs
+
+That's 18 resources in total in a single 230-line YAML template at `aws/cfn/networking/template.yaml`.
+
+## Why the Layered Pattern Matters
+
+I want to lock this concept in because it shapes everything that comes after.
+
+In a layered IaC architecture, each "layer" of the infrastructure is its own stack. Networking is one stack. The compute cluster is a separate stack. The database is a separate stack. The services that run on top of the cluster are yet another stack. They are deliberately decoupled.
+
+Why? Three reasons that came up over and over this week:
+
+1. **Different lifecycles.** I tear down my ECS cluster between sessions to save money, but I'd never want to tear down the network if there's data flowing through it. Keeping them in separate stacks means I can delete the cluster without disturbing the network.
+2. **Reusability.** Once I have my networking stack, multiple cluster stacks could consume its outputs. The network publishes; the consumers import. Neither needs to know about the other's internals.
+3. **Blast radius.** If I make a bad change to one stack, the failure is contained to that stack. Mixing networking and compute into one giant template means one typo can break everything.
+
+This is the textbook AWS pattern, and following it from the start gives my project a much stronger story for interviews.
+
+## The Tools I Set Up
+
+A few new pieces of tooling joined my workflow this week:
+
+- **`cfn-lint` 1.49.3** — a linter for CloudFormation templates. It catches YAML syntax errors, invalid property references, and AWS-specific issues (like trying to assign a property that doesn't exist on a resource type) *before* you ever attempt a deploy. I installed it via `pip3` and now every deploy script starts with a `cfn-lint` call as a guard rail.
+- **`pip3`** — needed installing first; came in via `apt`. A reminder that even my dev environment is something I'm assembling as I go.
+- **An S3 artifacts bucket** — `cfn-artifacts-cruddur-cf-1354`. CloudFormation uploads templates to S3 during the `aws cloudformation deploy` flow, so this bucket is now a permanent part of my project's environment.
+
+## The Deploy Script Pattern — `--no-execute-changeset`
+
+This is one of the most important habits I formed this week, and it's worth its own section.
+
+When you deploy a CloudFormation template, by default `aws cloudformation deploy` will create a change set, then immediately execute it. That's fine for trivial changes, but it's terrifying for anything that touches real infrastructure — because by the time you find out what's about to happen, it's already happening.
+
+The fix is `--no-execute-changeset`. With that flag, the deploy command creates the change set and stops. It tells me, "here's a description of what would change — go review it in the Console, and if you approve, click Execute yourself."
+
+My deploy script at `bin/cfn/networking-deploy` follows this pattern:
+
+```bash
+#!/usr/bin/env bash
+set -e
+CFN_PATH="aws/cfn/networking/template.yaml"
+
+cfn-lint $CFN_PATH
+
+aws cloudformation deploy \
+  --stack-name CrdNet \
+  --s3-bucket $CFN_BUCKET \
+  --region us-east-1 \
+  --template-file $CFN_PATH \
+  --no-execute-changeset \
+  --tags group=cruddur-networking \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+In an interview I'd describe this as the "production-safe deploy pattern" — eliminates a whole class of "I didn't realize this would replace the resource" incidents. It's also exactly how a real-world enterprise CI/CD pipeline should be wired: build a change set, post it for review, require a human approval before executing.
+
+## Three Full Deployment Cycles
+
+I deployed `CrdNet` three different times this week, on purpose:
+
+**Deploy #1 — Initial creation.** First run of the deploy script. cfn-lint passed silently. Template uploaded to S3. Change set created with 18 Add actions. Reviewed in the Console (every action, every resource type). Executed. Stack reached `CREATE_COMPLETE` in about 25 seconds.
+
+**Deploy #2 — Outputs fix.** I caught a problem during my four-layer verification (more on that below): the Outputs tab was empty. I had forgotten to actually include the `Outputs` section in the template, which meant my five cross-stack exports didn't exist yet. I appended the Outputs section via a heredoc, redeployed, reviewed the change set (which showed only Modify actions on the existing stack), and executed.
+
+**Deploy #3 — Full teardown and rebuild.** This was the one I'm proudest of. I ran `aws cloudformation delete-stack --stack-name CrdNet`, watched the 18 resources delete in reverse-dependency order (Route Table Associations first, then Routes/Subnets/IGW attachment, then VPC last). Verified in the Console that my account was back to a pre-Cruddur state (only the default VPC remained). Then I ran `./bin/cfn/networking-deploy` again — same template, no changes — and watched 18 resources come back in roughly the same 25 seconds. Same logical structure, brand-new physical IDs. That's the IaC promise made real: an entire production-style network environment, gone and back in under two minutes from a single YAML file.
+
+## Verify All Four Layers — Lesson Learned
+
+Deploy #1 finished with a green `CREATE_COMPLETE` banner. If I had stopped there I would have shipped a broken stack.
+
+The mistake was treating the stack status as the only truth. CloudFormation can absolutely report `CREATE_COMPLETE` while the *content* of the stack is wrong — for example, when the Outputs section is missing entirely. The status only tells you "everything I tried to create, I created." It doesn't tell you "everything you intended is here."
+
+The fix is a four-layer Console verification I now run after every deploy:
+
+1. **VPC Console → Your VPCs.** Is the new VPC present with the right CIDR?
+2. **VPC Console → Subnets.** Are all six subnets there, in the right AZs, with the right CIDRs?
+3. **VPC Console → Route Tables.** Are both route tables present, with the right routes, and associated with the right subnets?
+4. **CloudFormation → Stack → Outputs tab.** Are all five exports listed?
+
+It was step 4 that caught my Outputs bug. Now I always do all four, every time, even when the deploy "looks fine."
+
+## Debugging Case Studies
+
+Week 10 was as much a tooling and workflow shakedown as it was an IaC project. Several gnarly issues came up, and I want to document the ones that taught me something durable.
+
+### Kiro IDE Source Control panel — unreliable
+
+I started the week trying to use Kiro's built-in Git UI. Within an hour I had three separate situations where the panel showed files as modified when terminal `git status` showed them clean, and one where it surfaced an "Initialize Repository" button on a directory that already had a 321-commit history. If I had clicked it, I could have lost everything.
+
+The lesson: **the terminal is the authoritative source of truth for Git.** IDE Source Control panels are nice when they work, but they cache state aggressively and can misrepresent the repo. From this point forward, every Git operation goes through the terminal. I verify status, stage, commit, push, pull, and merge with `git` directly. The IDE is for editing files; nothing more.
+
+### WSL versus Windows filesystem boundary
+
+Launching Kiro from Windows pointed it at a Windows-side file path. Git inside WSL couldn't recognize my repo because the file ownership looked wrong (Windows files mounted into WSL show up with different owners than WSL-native files).
+
+The fix: I always launch Kiro from inside the WSL terminal by running `kiro .` from my repo directory. That way Kiro inherits the WSL environment and Git works normally. Belt-and-suspenders: I also ran `git config --global --add safe.directory $(pwd)` to whitelist my repo with Git's ownership protection.
+
+### CRLF versus LF line endings
+
+When I created a shell script on Windows and ran it inside WSL, I got an error that read `bash\r`. That trailing `\r` was the Carriage Return character — Windows uses CRLF (`\r\n`) to end lines while Linux uses LF (`\n`). My shell script had been silently corrupted with Windows line endings.
+
+Fix one-time: `sed -i 's/\r$//' bin/cfn/networking-deploy`. Fix permanently: I added a `.gitattributes` file telling Git to force LF on all shell scripts regardless of operating system.
+
+### Rogue branch on GitHub
+
+Earlier in the week, an accidental PowerShell commit had created a divergent `kiro-dev` branch on GitHub that no longer matched what was in WSL. Trying to push from WSL produced a "diverged history" error. I considered just force-pushing, but `git push --force` is genuinely dangerous — it can overwrite a teammate's work if you don't know exactly what you're doing.
+
+The correct fix was `git reset --hard origin/main` (to bring my local branch back in sync with `main`), then `git push --force-with-lease origin kiro-dev`. The `--force-with-lease` variant refuses to push if the remote has changed since I last fetched it — so even if I'm wrong about the state of the remote, I can't accidentally clobber someone else's commits.
+
+## SSL Bypass — Corporate Constraints
+
+A non-technical but important thread this week: my work laptop runs Zscaler SSL inspection and CrowdStrike Falcon Sensor. Both interfere with certain dev workflows — pulling from Docker Hub, opening tunnels via GitHub Codespaces, and reaching AWS ECR Public can all fail with TLS errors because Zscaler is replacing the upstream certificate with its own. I have a working bypass for AWS CLI traffic (`AWS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt` in my `.bashrc`) but Docker and a few other tools need explicit per-domain rules.
+
+I drafted a consultative email to Antwaun, my director of Cloud Operations, asking for guidance on whether I should approach Eric Holbrook in CT Cyber Security directly with a request to whitelist specific domains. Two variants of the email were prepared — a longer consultative version and a shorter direct-request version — both with placeholders for the relevant screenshots and exact error messages.
+
+This sits open as I move into Week 11. The takeaway here is that "corporate security policy" is part of the cloud engineering job too. Not every blocker is technical, and knowing how to escalate professionally is itself a skill.
+
+## Branch and PR Workflow
+
+All of this week's work happened on the `kiro-dev` branch. At the end of the week I opened PR #2 against `main`:
+
+- **Title:** Week 10: CloudFormation networking stack (Kiro dev)
+- **Base:** main, **Compare:** kiro-dev
+- **2 commits, 3 files changed**
+- Merged as commit `c9553b8` via "Create a merge commit" (the default option in GitHub's PR merge dialog)
+
+After the merge I synced my local `main`, deleted the local `kiro-dev` branch, and confirmed both branches were clean. This is the same flow I'll use for every IaC stack going forward.
+
+## What This Looks Like on My Resume
+
+If an interviewer asks "have you used CloudFormation?" I now have a real answer. I built a networking stack from scratch: VPC, IGW, six subnets across three AZs, two route tables, six route table associations, and five cross-stack exports. I deployed it three times — once to create, once to fix a missing Outputs section, and once as a full teardown-and-rebuild — to prove the IaC promise that an entire networking environment is reproducible from a single YAML file.
+
+I used the `--no-execute-changeset` pattern so every deploy goes through a human-reviewed change set in the Console before applying. I caught a Outputs bug because I run a four-layer verification (VPC, Subnets, Route Tables, Outputs) after every deploy rather than trusting the stack status alone. The work is committed to my public GitHub repo, merged through PR #2 with the layered cross-stack export pattern documented in the template's comments.
+
+It's a real artifact I can walk an interviewer through line by line.
+
+## Commands Reference
+
+```bash
+# Install cfn-lint
+pip3 install cfn-lint
+
+# Deploy (creates change set, does NOT execute)
+./bin/cfn/networking-deploy
+
+# Execute the change set from the Console:
+# CloudFormation → CrdNet → Change sets → [latest] → Execute
+
+# Verify deploy
+aws cloudformation describe-stacks --stack-name CrdNet \
+  --query "Stacks[0].Outputs" --output table
+
+# Tear down (asynchronous; takes ~30 seconds)
+aws cloudformation delete-stack --stack-name CrdNet
+
+# Confirm teardown
+aws cloudformation describe-stacks --stack-name CrdNet
+# Expected: "Stack with id CrdNet does not exist"
+
+# Fix Windows line endings on a shell script
+sed -i 's/\r$//' bin/cfn/networking-deploy
+
+# Safe forced push (refuses if remote moved)
+git push --force-with-lease origin kiro-dev
+```
+
+## Progress Checklist
+
+- [x] Install `pip3` and `cfn-lint` 1.49.3 in WSL Ubuntu 24
+- [x] Create `cfn-artifacts-cruddur-cf-1354` S3 bucket for template uploads
+- [x] Write `aws/cfn/networking/template.yaml` with VPC, IGW, six subnets, two route tables, six RTAs
+- [x] Add Outputs section with five cross-stack exports (`CrdNetVpcId`, `CrdNetVpcCidrBlock`, `CrdNetPublicSubnetIds`, `CrdNetPrivateSubnetIds`, `CrdNetAvailabilityZones`)
+- [x] Write `bin/cfn/networking-deploy` using `--no-execute-changeset` pattern
+- [x] Deploy #1 — initial creation, verified in Console (all four layers)
+- [x] Deploy #2 — corrective update after catching missing Outputs section
+- [x] Deploy #3 — full teardown and rebuild to prove reproducibility
+- [x] Resolve Kiro IDE Source Control panel cache bugs by moving Git workflow to terminal-only
+- [x] Resolve WSL/Windows filesystem boundary by launching Kiro from inside WSL
+- [x] Resolve CRLF line-ending corruption on shell scripts with `sed` and `.gitattributes`
+- [x] Resolve rogue `kiro-dev` branch on GitHub via `git reset --hard` and `git push --force-with-lease`
+- [x] Tear down `CrdNet` stack for cost discipline at end of session
+- [x] Open PR #2 from `kiro-dev` into `main`
+- [x] Merge PR #2 as commit `c9553b8`
+- [x] Sync local and remote branches; confirm working tree clean
+- [x] Draft SSL inspection bypass email to Antwaun (two variants)
+- [ ] Receive Antwaun's guidance on whether to approach Eric Holbrook directly for SSL bypass (carried into Week 11)

--- a/journal/week11.md
+++ b/journal/week11.md
@@ -1,47 +1,48 @@
-# Week 11 — CloudFormation Part 2
+# Week 11 — CloudFormation Part 2: Compute Layer + Architecture Documentation
 
 ## What I Set Out To Do
 
-Week 10 gave me a working CloudFormation networking stack (`CrdNet`). Week 11 was about three things on top of that:
+Week 10 gave me a working CloudFormation networking stack (CrdNet). Week 11 was about four things on top of that:
 
 1. **Refactoring the deploy workflow** to externalize configuration into a TOML file, so my scripts don't hardcode bucket names, regions, or stack names.
-2. **Building the compute layer** — a new `CrdCluster` stack defining my ECS Fargate cluster, the Application Load Balancer, listeners, target groups, and the ALB security group, all consuming the networking exports from `CrdNet`.
-3. **Drawing the network architecture diagram** in Lucid as a portfolio artifact and a debugging insurance policy.
+2. **Building the compute layer** — a new CrdCluster stack defining my ECS Fargate cluster, the Application Load Balancer, listeners, target groups, and the ALB security group, all consuming the networking exports from CrdNet.
+3. **Drawing a comprehensive network architecture diagram in Lucid** as a portfolio artifact and a debugging insurance policy, covering all current stacks (CrdNet, CrdCluster) AND the future-state stacks (CrdDb, CrdService) plus production-grade additions like NAT Gateway and cross-stack exports.
+4. **Documenting the entire architecture** in this journal as institutional knowledge that travels with the codebase.
 
-This was the densest week of the bootcamp so far. By the end of it I had two CloudFormation stacks deployed end-to-end, all eight cluster resources running, every connection in my architecture mapped on paper with explicit port labels, and a refactored deploy pipeline that follows the same configuration-externalization pattern used in real production systems.
+This was the densest week of the bootcamp so far. By the end of it I had two CloudFormation stacks deployed end-to-end, all eight cluster resources running, every connection in my architecture mapped on paper with explicit port labels, a refactored deploy pipeline that follows the same configuration-externalization pattern used in real production systems, and a portfolio-ready architecture diagram that demonstrates production-grade thinking.
 
 ---
 
-## Session A — `cfn-toml` Refactor
+## Session A — cfn-toml Refactor
 
-The detailed notes for this session live in **[`week11-session-a.md`](./week11-session-a.md)**, including the specific decisions I made (chose `ruby-apt` over `snap` for predictable system paths; used `--user-install` for cfn-toml to avoid `sudo`; kept `CFN_BUCKET` in `.bashrc` for interactive shell convenience while letting the TOML file own deploy-time config), the verification narrative, and the loose ends carried forward.
+The detailed notes for this session live in `week11-session-a.md`, including the specific decisions I made (chose ruby-apt over snap for predictable system paths; used `--user-install` for cfn-toml to avoid sudo; kept `CFN_BUCKET` in `.bashrc` for interactive shell convenience while letting the TOML file own deploy-time config), the verification narrative, and the loose ends carried forward.
 
-Quick summary: I refactored `bin/cfn/networking-deploy` to read `bucket`, `region`, and `stack_name` from `aws/cfn/networking/config.toml` instead of having those values baked into the script. Real values go in `config.toml` (gitignored). A placeholder `config.toml.example` is committed so anyone cloning the repo knows the schema. End-to-end verification confirmed the refactor produces an identical 18-resource, 5-export deploy — same outputs as Week 10, just sourced from a cleaner config layer.
+**Quick summary:** I refactored `bin/cfn/networking-deploy` to read bucket, region, and stack_name from `aws/cfn/networking/config.toml` instead of having those values baked into the script. Real values go in `config.toml` (gitignored). A placeholder `config.toml.example` is committed so anyone cloning the repo knows the schema. End-to-end verification confirmed the refactor produces an identical 18-resource, 5-export deploy — same outputs as Week 10, just sourced from a cleaner config layer.
 
 This is the same configuration-externalization pattern I already use for `.env` files in the application code, now applied to infrastructure. Real-world value: the same script can deploy to dev, staging, and prod by pointing at different TOML files, with no script edits.
 
 ---
 
-## Session B — Building the `CrdCluster` Stack
+## Session B — Building the CrdCluster Stack
 
 ### What the Stack Contains
 
 This is the compute layer of the application. The template at `aws/cfn/cluster/template.yaml` is 233 lines and defines:
 
-- An **ECS Fargate cluster** with Container Insights enabled and a Service Connect namespace
-- An **internet-facing Application Load Balancer** deployed across the three public subnets imported from `CrdNet`
-- An **HTTPS listener on port 443** with my ACM certificate for `*.fentoncruddur.com`, default forward to the frontend target group
-- An **HTTP listener on port 80** with a 301 redirect to HTTPS
-- A **listener rule** routing any request with host header `api.fentoncruddur.com` to the backend target group (priority 1)
-- A **backend target group** — port 4567, type `ip` (required for Fargate's `awsvpc` network mode), health check on `/api/health-check`
-- A **frontend target group** — port 3000, type `ip`, health check on `/`
-- An **ALB security group** allowing inbound TCP 443 and TCP 80 from `0.0.0.0/0`
+- An ECS Fargate cluster with Container Insights enabled and a Service Connect namespace
+- An internet-facing Application Load Balancer deployed across the three public subnets imported from CrdNet
+- An HTTPS listener on port 443 with my ACM certificate for `*.fentoncruddur.com`, default forward to the frontend target group
+- An HTTP listener on port 80 with a 301 redirect to HTTPS
+- A listener rule routing any request with host header `api.fentoncruddur.com` to the backend target group (priority 1)
+- A backend target group — port 4567, type `ip` (required for Fargate's `awsvpc` network mode), health check on `/api/health-check`
+- A frontend target group — port 3000, type `ip`, health check on `/`
+- An ALB security group allowing inbound TCP 443 and TCP 80 from `0.0.0.0/0`
 
-Eight resources total. Five cross-stack outputs (`ClusterName`, `ALBSecurityGroupId`, `HTTPSListenerArn`, `BackendTGArn`, `FrontendTGArn`) that future stacks will consume.
+**Eight resources total.** Five cross-stack outputs (ClusterName, ALBSecurityGroupId, HTTPSListenerArn, BackendTGArn, FrontendTGArn) that future stacks will consume.
 
 ### Cross-Stack Imports — The Whole Point of Layered IaC
 
-`CrdCluster` imports values from `CrdNet` using the `!ImportValue` intrinsic:
+CrdCluster imports values from CrdNet using the `!ImportValue` intrinsic:
 
 ```yaml
 Properties:
@@ -52,11 +53,11 @@ Properties:
       - !ImportValue CrdNetPublicSubnetIds
 ```
 
-That second pattern is worth pausing on. `CrdNet` exports `CrdNetPublicSubnetIds` as a comma-separated string because CloudFormation exports can only be strings, not lists. The cluster stack needs a list, so I have to split the string back at import time using the long-form `Fn::Split` intrinsic. The short-form `!Split` syntax does not nest cleanly inside `!ImportValue`. This is one of the bugs Andrew Brown specifically called out in his transcripts.
+That second pattern is worth pausing on. CrdNet exports `CrdNetPublicSubnetIds` as a comma-separated string because CloudFormation exports can only be strings, not lists. The cluster stack needs a list, so I have to split the string back at import time using the long-form `Fn::Split` intrinsic. The short-form `!Split` syntax does not nest cleanly inside `!ImportValue`. This is one of the bugs Andrew Brown specifically called out in his transcripts.
 
 ### Three Andrew-Known Bugs I Dodged Up Front
 
-Andrew's transcripts cover three subtle bugs that cost him hours in production. I made a point of dodging all three before deployment:
+Andrew Brown documented three subtle bugs in his bootcamp transcripts that cost him hours in production. I made a point of dodging all three before deployment:
 
 1. **Security group references for the ALB.** Use `!GetAtt ALBSecurityGroup.GroupId`, not `!Ref ALBSecurityGroup`. With `!Ref` you get the SG's logical name, not the GroupId the ALB resource actually needs, and the deploy fails with a confusing error.
 2. **Subnet selection.** Pass only the three public subnets to the ALB, not all six. Internet-facing ALBs cannot live in private subnets, and passing more than one subnet per AZ produces a uniqueness conflict.
@@ -66,23 +67,23 @@ The fact that none of these surfaced during deploy is the best evidence I had th
 
 ### One Bug I Did Hit — YAML Indentation
 
-I built the cluster template in five incremental chunks (parameters, resources, intrinsics, outputs, tagging). After chunk three, `cfn-lint` started complaining about an unrecognized property. After staring at the file for a few minutes I caught it — the property was at the wrong indentation level. YAML treats indentation as semantically meaningful, so an extra two spaces had turned a top-level resource property into a nested sub-property of the wrong key.
+I built the cluster template in five incremental chunks (parameters, resources, intrinsics, outputs, tagging). After chunk three, cfn-lint started complaining about an unrecognized property. After staring at the file for a few minutes I caught it — the property was at the wrong indentation level. YAML treats indentation as semantically meaningful, so an extra two spaces had turned a top-level resource property into a nested sub-property of the wrong key.
 
-This is the kind of bug that doesn't exist in JSON (which uses explicit braces) but is a constant hazard in YAML. `cfn-lint` caught it in seconds; otherwise I would have caught it eventually at deploy time at much higher cost. The lesson is that `cfn-lint` is a critical guardrail — every deploy script's first step.
+This is the kind of bug that doesn't exist in JSON (which uses explicit braces) but is a constant hazard in YAML. cfn-lint caught it in seconds; otherwise I would have caught it eventually at deploy time at much higher cost. The lesson is that **cfn-lint is a critical guardrail — every deploy script's first step**.
 
-### The `bash -x` Detour
+### The bash -x Detour
 
-While testing the cluster deploy script for the first time, I accidentally ran `bash -x` against it. `bash -x` traces and executes every line — which meant the script ran end-to-end *without my eyes on it*, including the `aws cloudformation deploy` call. It uploaded the template to S3 and created a change set against a stub `CrdCluster` stack.
+While testing the cluster deploy script for the first time, I accidentally ran `bash -x` against it. `bash -x` traces *and executes* every line — which meant the script ran end-to-end without my eyes on it, including the `aws cloudformation deploy` call. It uploaded the template to S3 and created a change set against a stub CrdCluster stack.
 
-Because the script uses `--no-execute-changeset`, **no resources were actually deployed**. The stub stack and its change set were free to clean up:
+Because the script uses `--no-execute-changeset`, no resources were actually deployed. The stub stack and its change set were free to clean up:
 
 ```bash
 aws cloudformation delete-stack --stack-name CrdCluster
 ```
 
-The damage was zero, but the lesson was sharp: **read before you run.** Don't grab a script you're still tuning and pipe it through anything that auto-executes. That's the kind of mistake that, in a real production environment, ends up on a postmortem. I'd rather learn it here on a stub stack than later on a production cluster.
+The damage was zero, but the lesson was sharp: **read before you run**. Don't grab a script you're still tuning and pipe it through anything that auto-executes. That's the kind of mistake that, in a real production environment, ends up on a postmortem. I'd rather learn it here on a stub stack than later on a production cluster.
 
-After cleanup, I committed the cluster scaffolding as `6402f77`:
+After cleanup, I committed the cluster scaffolding as commit `6402f77`:
 
 ```
 feat(cfn): add cluster stack scaffolding for ECS Fargate + ALB
@@ -90,13 +91,13 @@ feat(cfn): add cluster stack scaffolding for ECS Fargate + ALB
 
 ---
 
-## Session C — End-to-End Deployment of `CrdCluster`
+## Session C — End-to-End Deployment of CrdCluster
 
 This was the big one. The first true deployment of the cluster stack against a live AWS account.
 
 ### Phase 1 — Deploy CrdNet First
 
-The cluster stack imports from `CrdNet`, so the networking stack has to exist in the account before the cluster's `!ImportValue` references can resolve.
+The cluster stack imports from CrdNet, so the networking stack has to exist in the account before the cluster's `!ImportValue` references can resolve.
 
 ```bash
 ./bin/cfn/networking-deploy
@@ -110,17 +111,17 @@ Reviewed the change set in the Console (18 Add actions, all subnets, RTAs, route
 ./bin/cfn/cluster-deploy
 ```
 
-This was the held-breath moment. Reviewed the change set carefully — 8 Add actions for `FargateCluster`, `ALBSecurityGroup`, `ALB`, `HTTPSListener`, `HTTPListener`, `ApiALBListenerRule`, `FrontendTG`, `BackendTG`. Reviewed the Parameters tab to confirm cfn-toml had populated the four expected values (the certificate ARN, the host header for `api.fentoncruddur.com`, the frontend health check path, the backend health check path). Both correct. Executed.
+This was the held-breath moment. Reviewed the change set carefully — 8 Add actions for FargateCluster, ALBSecurityGroup, ALB, HTTPSListener, HTTPListener, ApiALBListenerRule, FrontendTG, BackendTG. Reviewed the Parameters tab to confirm cfn-toml had populated the four expected values (the certificate ARN, the host header for `api.fentoncruddur.com`, the frontend health check path, the backend health check path). All correct. Executed.
 
-The deploy took about three minutes total. The ALB alone took roughly 75 seconds — AWS provisions it across multiple AZs with health checking and DNS setup, and that orchestration is genuinely slower than spinning up lighter resources. On every future cluster deploy, the ALB will be the bottleneck.
+The deploy took about three minutes total. **The ALB alone took roughly 75 seconds** — AWS provisions it across multiple AZs with health checking and DNS setup, and that orchestration is genuinely slower than spinning up lighter resources. On every future cluster deploy, the ALB will be the bottleneck.
 
-The dependency cascade resolved exactly as expected: `FargateCluster` and `ALBSecurityGroup` first (parallel, no dependencies), then `ALB` (depends on the SG and the public subnets), then the two target groups (depend on the VPC), then the two listeners (depend on the ALB and TGs), then `ApiALBListenerRule` last (depends on the HTTPS listener and the backend TG).
+The dependency cascade resolved exactly as expected: FargateCluster and ALBSecurityGroup first (parallel, no dependencies), then ALB (depends on the SG and the public subnets), then the two target groups (depend on the VPC), then the two listeners (depend on the ALB and TGs), then ApiALBListenerRule last (depends on the HTTPS listener and the backend TG).
 
 All 8 resources reached `CREATE_COMPLETE`. The Outputs tab populated with the 5 expected exports. Cross-stack imports worked live. No bugs surfaced.
 
 ### Phase 3 — Teardown in Reverse Dependency Order
 
-CloudFormation enforces a hard rule: you cannot delete a stack whose exports are still being imported by another stack. So teardown has to mirror deployment order — child stacks first, parent stacks last.
+CloudFormation enforces a hard rule: **you cannot delete a stack whose exports are still being imported by another stack.** So teardown has to mirror deployment order — child stacks first, parent stacks last.
 
 ```bash
 # CrdCluster first (ALB deletion is the bottleneck again — ~2 min)
@@ -135,112 +136,182 @@ aws cloudformation describe-stacks --stack-name CrdCluster \
 aws cloudformation delete-stack --stack-name CrdNet
 ```
 
-Both went clean. The "mirror-image dependency reversal" is the pattern that applies to all layered IaC. Deploy bottom-up, tear down top-down. I'll see this same shape on every multi-stack architecture for the rest of my career.
+Both went clean. **The "mirror-image dependency reversal" is the pattern that applies to all layered IaC.** Deploy bottom-up, tear down top-down. I'll see this same shape on every multi-stack architecture for the rest of my career.
 
 ---
 
 ## Session D — The Network Architecture Diagram
 
-The last big piece of the week. Andrew Brown explicitly called out in his transcripts that a clear network architecture diagram would have saved him hours of debugging on multiple occasions. The reason is simple: when you can *see* every connection and every port at a glance, certain classes of bug — like accidentally putting a service security group on port 80 when the container is listening on port 4567 — become visually obvious.
+The last and densest piece of the week. Andrew Brown explicitly called out in his transcripts that a clear network architecture diagram would have saved him hours of debugging on multiple occasions. The reason is simple: when you can see every connection and every port at a glance, certain classes of bug — like accidentally putting a service security group on port 80 when the container is listening on port 4567 — become visually obvious.
 
-I built the diagram in Lucid using a layered AI-prompt approach (one prompt per layer, then iterative cleanup). The Lucid URL is saved to my project memory.
+I built the diagram in Lucid using a layered approach: one prompt per architectural layer, then iterative manual cleanup. The Lucid URL is saved to my project memory, and exported PNG screenshots are committed to the repo.
+
+### The Layered Build Approach
+
+After an early attempt at single-prompt diagram generation produced cluttered, hard-to-correct output, I restarted with a disciplined layered approach. Each "layer" was added on top of the previous, with verification after each step:
+
+1. **External resources** — Client/User, Route 53, ACM Certificate, AWS Cloud frame
+2. **VPC and Internet Gateway** — CrdNet VPC at `10.0.0.0/16`, CrdNetIGW, Internet icon outside AWS Cloud
+3. **Availability Zones, subnets, route tables** — three AZ columns side-by-side, each with one public above one private subnet, plus Public and Private Route Tables with their associations
+4. **CrdCluster Stack (deployed, teal solid border)** — ALB spanning the public subnets, ALB Security Group, listeners with ACM cert and 301 redirect, target groups (Frontend on 3000, Backend on 4567 with HC port explicit), Fargate cluster, Service Security Group with the critical port 4567 annotation
+5. **CrdDb Stack (future, green dashed border)** — RDS PostgreSQL, DB Subnet Group, DB Security Group, cross-SG reference allowing 5432 from Service SG
+6. **CrdService Stack (future, magenta dashed border)** — Frontend and Backend Fargate tasks placed inside private subnets in us-east-1a and us-east-1b for high availability, with dashed lines to their target groups and from Backend tasks to RDS
+7. **NAT Gateway addition** — CrdNetNAT in Public Subnet A with `outbound :443` to IGW, Private Route Table updated to route `0.0.0.0/0` to NAT (enables tasks to pull container images from ECR)
+8. **Cross-Stack Exports table** — bottom-right corner, color-coded by stack, listing all 17 exports across the three stacks
 
 ### What the Diagram Shows
 
 External entities on the left: a Client/User, Route 53 (managing both `fentoncruddur.com` and `api.fentoncruddur.com`), and ACM Certificate Manager (issuing the `*.fentoncruddur.com` certificate).
 
-The AWS Cloud boundary on the right contains:
+The AWS Cloud boundary on the right contains everything else:
 
-- **CrdNet Stack (blue boundary)** — VPC `10.0.0.0/16`, the Internet Gateway, both route tables, and all six subnets organized into three vertical AZ columns (`us-east-1a/b/c`). Each column has one public subnet stacked above one private subnet.
-- **CrdCluster Stack (orange boundary)** — the ALB, both security groups (ALB and Service), the Fargate cluster, the two target groups.
-- **CrdDb Stack (green dashed boundary)** — RDS in the private subnets, the DB subnet group, the DB security group. Dashed because it's not yet built; that's Week 12.
+- **CrdNet Stack (blue solid boundary)** — VPC `10.0.0.0/16`, CrdNetIGW, both route tables, and all six subnets organized into three vertical AZ columns (us-east-1a/b/c). Each column has one public subnet stacked above one private subnet.
+- **CrdCluster Stack (teal solid boundary)** — the ALB spanning all three public subnets via attachment lines, both security groups (ALB SG with `:443/:80 from 0.0.0.0/0`, Service SG with `:4567 from ALB SG`), the Fargate cluster, and the two target groups with explicit port and health check port labels.
+- **CrdDb Stack (green dashed boundary)** — RDS in the private subnets, the DB Subnet Group spanning Private A/B/C, the DB Security Group with `:5432 from Service SG`. Dashed because it's not yet built; that's Week 12.
+- **CrdService Stack (magenta dashed boundary)** — Frontend and Backend Fargate task icons placed inside Private Subnet A and Private Subnet B (multi-AZ HA), with dashed lines connecting them to their target groups and Backend tasks connecting to RDS on port 5432.
+- **CrdNetNAT (in Public Subnet A)** — outbound NAT Gateway providing internet egress for private subnet resources (specifically, for Fargate tasks to pull container images from ECR).
+- **Cross-Stack Exports table (bottom-right, outside AWS Cloud)** — reference card showing 17 exports across three stacks, color-coded to match stack boundaries.
+
+### Every Port Has a Label — On Purpose
 
 Every connection line has its port labeled. The most important "insurance policy" labels:
 
-- Client → ALB on `:443` and `:80`
-- ALB → BackendTG → backend task on `:4567` (**not** `:80`)
-- ALB → FrontendTG → frontend task on `:3000`
-- ServiceSG inbound from ALBSG on `:4567` (**not** `:80`) — this is the bug that took Andrew and Bako two debugging sessions to find
-- Backend task → RDS on `:5432`
+- Internet → ALB on `:443 and :80`
+- ALB → BackendTG on `:4567`
+- ALB → FrontendTG on `:3000`
+- BackendTG → Backend tasks on `:4567`
+- FrontendTG → Frontend tasks on `:3000`
+- Service SG inbound from ALB SG on `:4567` (**not :80** — see "Why This Diagram Exists" section below)
+- Backend tasks → RDS on `:5432`
+- DB SG inbound from Service SG on `:5432`
+- Private subnet egress → NAT Gateway → IGW for ECR image pulls (`outbound :443`)
 
-Every port label is "redundant" in the sense that the same information is available by clicking into AWS Console pages. The redundancy is the point. When the diagram is in front of me during a debugging session, port misalignment is visible at a glance.
+Every port label is "redundant" in the sense that the same information is available by clicking into AWS Console pages. **The redundancy is the point.** When the diagram is in front of me during a debugging session, port misalignment is visible at a glance.
+
+### Lessons from Iterating with Lucid AI
+
+Building this diagram took longer than expected because Lucid AI is unreliable for complex multi-component additions. Specifically:
+
+- **Single-prompt mega-generation produces unusable output.** My first attempt to generate the whole diagram from one comprehensive prompt resulted in inverted spatial layout, AZ columns stacked instead of side-by-side, and connection lines routing through unrelated components.
+- **Lucid AI is creative when it should be literal.** Multiple times it added components I didn't ask for (an extra "ECS Fargate Container" labeled wrong, a duplicate AWS Account wrapper) while skipping things I did ask for (HTTPS Listener annotations, security group ingress rules).
+- **Position-and-add prompts get half-executed.** When a prompt includes "add component X at position Y with annotation Z and a connection line to W," Lucid AI tends to do one or two of those four things and ignore the rest.
+- **Manual editing is faster after Layer 3.** Once the basic structure (VPC, subnets, route tables) was correct, every subsequent layer was faster to add by manually placing icons and drawing lines than by crafting prompts and correcting AI output.
+
+**Practical conclusion for future AI-assisted diagramming:** Use AI prompts for initial scaffolding and high-level structure. Switch to manual editing for any layer with multiple components, positioning constraints, or annotations. Don't fight the tool.
+
+### A Conceptual Detour: Target Groups vs. Security Groups
+
+Midway through building the cluster layer, I drew the FrontendTG as a dashed container surrounding the public subnets because "tasks would eventually live there." This turned out to be wrong on two levels:
+
+1. **Architectural error:** Frontend tasks belong in *private* subnets, not public. Only the ALB lives in public subnets. So drawing FrontendTG around the public subnets implied the wrong deployment model.
+2. **Conceptual error:** Target Groups don't *contain* anything physically. A TG is a routing configuration — a list of registered target IPs maintained by the ALB. It tells the ALB "when traffic gets forwarded to me, send it to these IPs on this port, and use this port for health checks." It doesn't live in any subnet, doesn't have its own security group, and doesn't sit on the network plumbing layer.
+
+The correct mental model is that TGs and SGs are at different points in the traffic flow, working *together* but never *containing* each other:
+
+```
+Internet → ALB SG → ALB → Listener Rule → Target Group → Task ENI → Service SG → Container
+   (firewall)              (routing)        (routing)        (firewall)
+```
+
+ALB SG and Service SG are firewalls attached to ENIs. Target Groups are routing configurations. Listener Rules decide *which* TG receives the traffic.
+
+**Interview takeaway:** "Target Groups and Security Groups serve completely different purposes. Target Groups are ALB routing configurations — they specify what port to forward to and how to health-check targets. Security Groups are firewall rules attached to network interfaces. In Fargate AWSVPC mode, each task gets its own ENI with the Service SG attached, and the ALB's ENIs have the ALB SG attached. When traffic flows from internet to container, it passes through the ALB SG, then gets routed by the listener to a Target Group, then forwarded to a task IP, where the Service SG decides whether to allow the connection on port 4567."
+
+This is the kind of conceptual precision that distinguishes someone who knows the AWS icons from someone who understands the architecture.
 
 ### A Mermaid Recreation
 
-For posterity in this journal, here's a Mermaid recreation of the Lucid diagram. It's lower-fidelity (no AWS icons, no perfect AZ columns), but it captures every resource, every cross-stack relationship, and every port label:
+For posterity in this journal, here's a Mermaid recreation of the Lucid diagram. It's lower-fidelity (no AWS icons, no perfect AZ columns, no color-coded stack boundaries), but it captures every resource, every cross-stack relationship, and every port label:
 
 ```mermaid
-flowchart TB
-    Client["Client / User"]
-    R53["Route 53<br/>fentoncruddur.com<br/>api.fentoncruddur.com"]
-    ACM["ACM Certificate<br/>*.fentoncruddur.com"]
-    Net(("Internet"))
-
-    Client -->|DNS lookup| R53
-    Client -->|HTTPS traffic| Net
-    Net -->|":443 / :80"| IGW
-
-    subgraph VPC["VPC CrdNet — 10.0.0.0/16"]
-        IGW["CrdNetIGW"]
-
-        subgraph PubLayer["Public Layer (route 0.0.0.0/0 → IGW)"]
-            direction LR
-            PubA["Public Subnet A<br/>us-east-1a<br/>10.0.0.0/24"]
-            PubB["Public Subnet B<br/>us-east-1b<br/>10.0.1.0/24"]
-            PubC["Public Subnet C<br/>us-east-1c<br/>10.0.2.0/24"]
+graph TB
+    Client[Client/User]
+    R53[Route 53<br/>fentoncruddur.com<br/>api.fentoncruddur.com]
+    ACM[ACM Cert<br/>*.fentoncruddur.com]
+    IGW[CrdNetIGW]
+    NAT[CrdNetNAT]
+    
+    subgraph VPC["CrdNet VPC — 10.0.0.0/16"]
+        subgraph CrdCluster["CrdCluster Stack — DEPLOYED"]
+            ALB[CrdClusterALB<br/>multi-AZ]
+            ALBSG[CrdClusterALBSG<br/>:443/:80 from 0.0.0.0/0]
+            SvcSG[CrdClusterServiceSG<br/>:4567 from ALB SG]
+            FTG[FrontendTG<br/>port 3000 / HC 3000]
+            BTG[BackendTG<br/>port 4567 / HC 4567]
+            Cluster[CrdClusterFargateCluster]
         end
-
-        subgraph Cluster["CrdCluster Stack"]
-            ALBSG["CrdClusterALBSG<br/>in: :443, :80 from 0.0.0.0/0"]
-            ALB["CrdClusterALB<br/>multi-AZ"]
-            FTG["FrontendTG<br/>:3000 | type ip"]
-            BTG["BackendTG<br/>:4567 | type ip"]
-            FargateCluster["CrdClusterFargateCluster<br/>ECS Fargate"]
-            ServiceSG["CrdClusterServiceSG<br/>in: :4567 from ALBSG"]
+        
+        subgraph CrdDb["CrdDb Stack — FUTURE"]
+            RDS[Amazon RDS<br/>cruddur-instance<br/>db.t4g.micro]
+            DbSG[CrdDbSG<br/>:5432 from Service SG]
         end
-
-        subgraph PrivLayer["Private Layer (route 10.0.0.0/16 → local)"]
-            direction LR
-            PrivA["Private Subnet A<br/>us-east-1a<br/>10.0.4.0/24"]
-            PrivB["Private Subnet B<br/>us-east-1b<br/>10.0.5.0/24"]
-            PrivC["Private Subnet C<br/>us-east-1c<br/>10.0.6.0/24"]
-        end
-
-        subgraph DbStack["CrdDb Stack (future — Week 12)"]
-            DbSG["CrdDbSG<br/>in: :5432 from ServiceSG"]
-            RDS["Amazon RDS<br/>PostgreSQL"]
+        
+        subgraph CrdService["CrdService Stack — FUTURE"]
+            FTA[Frontend Task A<br/>Fargate :3000]
+            FTB[Frontend Task B<br/>Fargate :3000]
+            BTA[Backend Task A<br/>Fargate :4567]
+            BTB[Backend Task B<br/>Fargate :4567]
         end
     end
-
+    
+    Client -->|DNS lookup| R53
+    R53 -->|DNS resolution| ALB
+    ACM -.->|cert attached| ALB
+    
+    Client -->|:443 / :80| IGW
     IGW --> ALB
-    ACM -.->|cert| ALB
-    ALB -->|protected by| ALBSG
-    ALB -->|":3000"| FTG
-    ALB -->|":4567"| BTG
-    FTG --> FargateCluster
-    BTG --> FargateCluster
-    FargateCluster -->|protected by| ServiceSG
-    FargateCluster -.->|":5432"| RDS
-    RDS -.->|protected by| DbSG
-    ALBSG -.->|allows :4567| ServiceSG
-    ServiceSG -.->|allows :5432| DbSG
-
-    classDef netStack fill:#e3f2fd,stroke:#1976d2,stroke-width:2px,color:#000
-    classDef clusterStack fill:#fff3e0,stroke:#f57c00,stroke-width:2px,color:#000
-    classDef dbStack fill:#e8f5e9,stroke:#388e3c,stroke-width:2px,stroke-dasharray:5 5,color:#000
-    classDef external fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px,color:#000
-
-    class IGW,PubA,PubB,PubC,PrivA,PrivB,PrivC netStack
-    class ALB,ALBSG,FTG,BTG,FargateCluster,ServiceSG clusterStack
-    class RDS,DbSG dbStack
-    class Client,R53,ACM,Net external
+    
+    ALB -->|:4567| BTG
+    ALB -->|:3000| FTG
+    
+    BTG -.->|:4567| BTA
+    BTG -.->|:4567| BTB
+    FTG -.->|:3000| FTA
+    FTG -.->|:3000| FTB
+    
+    ALBSG -.->|allows :4567| SvcSG
+    SvcSG -.->|allows :5432| DbSG
+    
+    BTA -.->|:5432| RDS
+    BTB -.->|:5432| RDS
+    
+    NAT -->|outbound :443| IGW
+    BTA -.->|egress to ECR| NAT
 ```
 
-### Why This Diagram Lives in My Repo
+The Lucid version is the canonical one with proper AWS icons and clean spatial flow; this Mermaid version lives in the journal as a permanent record that travels with the codebase and renders in GitHub.
 
-This is portfolio material. When an interviewer asks "walk me through your architecture," I can pull this up and point at every box. When I'm debugging a connectivity issue, I can trace the path from client to container with my finger and check whether each port matches what's deployed. When I add `CrdDb` and `CrdService` in Week 12, I'll convert those dashed boundaries to solid lines and the diagram evolves with the project.
+---
 
-The Lucid version is the canonical one; the Mermaid version above lives in this journal as a permanent record that travels with the codebase.
+## Why This Diagram Exists: A Real Production Bug
+
+This deserves its own section because it's the entire reason I invested the time.
+
+### The Bug
+
+In Andrew Brown's bootcamp transcripts, he and Bako spent two debugging sessions on a Fargate connectivity problem. The setup looked correct: ALB security group allowed port 80 from the internet, Service security group allowed port 80 from the ALB security group, target group was configured on the container's port (4567). The ALB couldn't reach the containers. Health checks failed. Traffic dropped.
+
+The fix, after extensive debugging: **change the Service SG to allow port 4567 from the ALB SG, not port 80.** Also: explicitly set the target group health check port to 4567, not "traffic port" (which defaulted to something wrong).
+
+### Why It Happens
+
+Fargate's `awsvpc` networking mode is what causes this. In `awsvpc` mode, every task gets its own Elastic Network Interface (ENI) with its own private IP in the subnet. The ALB doesn't connect to tasks via the cluster's instance host port — it connects **directly to the task ENI on the container port**. There's no port translation between the ALB listener (:80 or :443) and the container port (:4567). The ALB just opens a TCP connection to `task-ip:4567`.
+
+So the Service SG, which guards the task ENI, has to allow port 4567 — *the container port*, not the listener port. Anyone reasoning from "the ALB listens on 80, so the SG must allow 80" gets the architecture wrong and the deploy fails silently (health checks just don't pass).
+
+### Why a Diagram Prevents This Bug
+
+When the diagram is in front of you, the port chain is visible: `:443 → :4567 → :4567 → :5432`. There's no `:80` anywhere between the ALB and the container. Anyone — me, a teammate, an interview candidate I'm onboarding — can read this in 5 seconds and write the correct SG rule.
+
+Without the diagram, the bug is invisible until deployment fails. With the diagram, the bug is impossible to introduce.
+
+### The Interview Narrative
+
+This is the answer to "tell me about a production debugging case study you've worked through":
+
+> "During the bootcamp, we hit a Fargate networking bug where the service security group was configured to allow port 80 from the ALB security group, which seemed correct because port 80 is the ALB listener port. But Fargate's AWSVPC networking mode bypasses port translation — the ALB sends traffic directly to the task ENI on the container port. So the SG needed to allow 4567, not 80. It took two debugging sessions and another engineer to find. After that, I documented the architecture in a Lucid diagram with the port mapping called out as a CRITICAL annotation, so the bug can't reappear silently in future deployments. The diagram shows every connection labeled with its port, and the chain from ALB listener (443) to target group (4567) to container port (4567) to service SG (4567) to database (5432) is all visible at a glance. Want me to walk through it?"
+
+That answer demonstrates: production debugging experience, AWS networking depth, infrastructure documentation discipline, and a habit of converting bugs into institutional knowledge. All four are things hiring managers explicitly look for in cloud engineering candidates.
 
 ---
 
@@ -250,13 +321,45 @@ The Lucid version is the canonical one; the Mermaid version above lives in this 
 
 Both stacks were deployed, verified, and torn down within the same sessions. The ALB alone costs roughly $0.0225/hour (~$0.55/day) regardless of traffic. The other seven cluster resources are essentially free at rest, but the ALB is enough that I never leave it running between sessions. Every session ends with both stacks gone and `describe-stacks` returning "does not exist."
 
+When CrdDb is added in Week 12, the RDS instance will become the new ongoing cost driver — `db.t4g.micro` is free-tier eligible but if I exhaust free-tier hours, it's roughly $0.016/hour. Still, the discipline holds: tear down at session close, redeploy at session start, prove reproducibility on every cycle.
+
 ### The Reproducibility Promise
 
-I proved this week, on a more substantial scale than Week 10, that a 26-resource multi-stack architecture (18 networking + 8 cluster) can be torn down and rebuilt identically in roughly four minutes from two YAML files and two TOML configs. That's the whole point of Infrastructure as Code. Until you see it work, it's abstract. Once you watch it happen, it changes how you think about every piece of infrastructure you'll ever own.
+I proved this week, on a more substantial scale than Week 10, that a 26-resource multi-stack architecture (18 networking + 8 cluster) can be torn down and rebuilt identically in roughly four minutes from two YAML files and two TOML configs. **That's the whole point of Infrastructure as Code.** Until you see it work, it's abstract. Once you watch it happen, it changes how you think about every piece of infrastructure you'll ever own.
 
 ### Read Before You Run
 
 The `bash -x` incident was harmless because of the `--no-execute-changeset` guard, but it taught me something durable: I never want to be in a position where a script auto-executes its way past a step I haven't reviewed. From now on, every new script gets reviewed end-to-end before execution. Every deploy script uses `--no-execute-changeset` by default. Every destructive operation prompts for confirmation.
+
+### AI Tooling: Useful but Untrusted
+
+Lucid AI accelerated the early skeleton of the diagram but was unreliable for complex additions. The pattern I learned: AI is good for "scaffolding-shaped tasks" with one or two simple structural changes. AI is bad for "production-shaped tasks" with multiple positioning constraints, annotations, and connection requirements. The judgment is *when to switch from AI to manual editing*, and the cost of switching too late is wasted prompt cycles and frustrated iteration.
+
+This pattern almost certainly generalizes beyond diagramming. AI as a force multiplier for the easy parts; human judgment for the parts where precision and architectural intent matter.
+
+### Visual Documentation as Bug Prevention
+
+The diagram isn't decoration. It's an active line of defense against a specific class of architectural bug. The next time I (or a teammate) configures a Fargate security group, the diagram on the wall makes the correct port choice obvious. The hour spent labeling every connection with its port saves an unknown number of future debugging hours — and that's the right trade for any production system.
+
+### Target Groups Are Not Security Groups
+
+The conceptual detour mid-diagram (drawing FrontendTG as a container, then learning that's wrong) was one of the highest-value learnings of the week. The precise model — TGs are routing, SGs are firewalls, and they operate at different points in the traffic flow — is the kind of detail that distinguishes engineers who can pass an AWS Solutions Architect exam from engineers who can actually debug production. Both required, but only one is interesting in an interview.
+
+---
+
+## Skills Demonstrated
+
+For portfolio/interview purposes, here's what this week's work demonstrates:
+
+- **Multi-stack CloudFormation architecture** with cross-stack imports/exports (`!ImportValue`, `Fn::Split`, `Outputs` with explicit `Export.Name`)
+- **AWS networking patterns** — VPC, public/private subnets across AZs, Internet Gateway, NAT Gateway for private-subnet egress, route table associations
+- **Defense-in-depth via SG-to-SG references** — security group rules referencing other security groups by ID, not by CIDR, for the complete chain Internet → ALB SG → Service SG → DB SG
+- **Configuration externalization** via TOML files (`cfn-toml`) — separation of secrets, environment-specific values, and deployment metadata from code
+- **Architectural documentation** as a portfolio artifact and bug-prevention layer
+- **Production safety patterns** — `--no-execute-changeset` for change-set review, dependency-ordered deploy/teardown, deletion-policy thinking
+- **Tooling judgment** — knowing when to use AI assistance vs. manual editing, recognizing when iteration costs exceed value
+- **CloudFormation lifecycle thinking** — change sets vs. direct deploys, dependency cascades, the ALB as the consistent bottleneck
+- **Fargate AWSVPC-mode networking** — understanding how task ENIs differ from instance host networking, why container ports flow through to security groups, why TG health checks need explicit port configuration
 
 ---
 
@@ -279,26 +382,32 @@ aws cloudformation describe-stacks --stack-name CrdCluster \
 # Then CrdNet
 aws cloudformation delete-stack --stack-name CrdNet
 
-# Inspect stack outputs
+# Inspect stack outputs (verify cross-stack exports)
 aws cloudformation describe-stacks --stack-name CrdCluster \
   --query "Stacks[0].Outputs" --output table
+
+# Lint a template before deploy
+cfn-lint aws/cfn/cluster/template.yaml
+
+# Validate cfn-toml config parsing
+cfn-toml -t aws/cfn/cluster/config.toml
 ```
 
 ---
 
 ## Progress Checklist
 
-### Session A — `cfn-toml` Refactor
-See [`week11-session-a.md`](./week11-session-a.md) for full notes.
+### Session A — cfn-toml Refactor
+See `week11-session-a.md` for full notes.
 
 - [x] Refactor `bin/cfn/networking-deploy` to read from `aws/cfn/networking/config.toml`
 - [x] Create `config.toml.example` (committed) and `config.toml` (gitignored)
 - [x] End-to-end verification — same 18 resources, same 5 outputs as Week 10 baseline
 
-### Session B — `CrdCluster` Scaffolding
+### Session B — CrdCluster Scaffolding
 - [x] Write `aws/cfn/cluster/template.yaml` (233 lines, 8 resources, 5 outputs)
 - [x] Define ECS Fargate cluster with Container Insights and Service Connect namespace
-- [x] Define internet-facing ALB in public subnets imported from `CrdNet`
+- [x] Define internet-facing ALB in public subnets imported from CrdNet
 - [x] Define HTTPS listener (port 443) with ACM cert and default forward to FrontendTG
 - [x] Define HTTP listener (port 80) with 301 redirect to HTTPS
 - [x] Define listener rule routing `api.fentoncruddur.com` host header to BackendTG (priority 1)
@@ -307,35 +416,85 @@ See [`week11-session-a.md`](./week11-session-a.md) for full notes.
 - [x] Define ALBSecurityGroup (allow 443 and 80 from 0.0.0.0/0)
 - [x] Create cfn-toml config files for cluster stack
 - [x] Create `bin/cfn/cluster-deploy` using cfn-toml params v2 pattern
-- [x] Catch and fix YAML indentation bug surfaced by `cfn-lint`
+- [x] Catch and fix YAML indentation bug surfaced by cfn-lint
 - [x] Dodge three Andrew-known bugs (SG `!GetAtt`, public-only subnets, long-form intrinsics)
 - [x] Recover from accidental `bash -x` execution; verify zero damage
 - [x] Commit cluster scaffolding as `6402f77`
 
 ### Session C — End-to-End Deployment
-- [x] Deploy `CrdNet` (prerequisite for cluster imports)
-- [x] Deploy `CrdCluster` end-to-end — all 8 resources reach CREATE_COMPLETE
+- [x] Deploy CrdNet (prerequisite for cluster imports)
+- [x] Deploy CrdCluster end-to-end — all 8 resources reach `CREATE_COMPLETE`
 - [x] Verify ALB took ~75 seconds (expected bottleneck)
-- [x] Verify cross-stack imports resolved correctly (`VpcId`, `PublicSubnetIds`)
+- [x] Verify cross-stack imports resolved correctly (VpcId, PublicSubnetIds)
 - [x] Verify three Andrew-known bugs all dodged (deploy success is the proof)
-- [x] Verify 5 outputs populated in `CrdCluster` Outputs tab
-- [x] Tear down `CrdCluster` first, then `CrdNet` (reverse dependency order)
+- [x] Verify 5 outputs populated in CrdCluster Outputs tab
+- [x] Tear down CrdCluster first, then CrdNet (reverse dependency order)
 - [x] Verify both stacks return "does not exist"
 
 ### Session D — Network Architecture Diagram
 - [x] Plan diagram layout (external entities left, AWS Cloud right, AZ columns vertical)
-- [x] Generate diagram via layered Lucid AI prompts
-- [x] Label every connection line with its port number (especially `:4567 not :80` for ServiceSG)
-- [x] Color-code stacks (CrdNet blue, CrdCluster orange, CrdDb green dashed)
+- [x] Iterate through layered build approach (8 layers added incrementally)
+- [x] Build CrdNet layer (VPC, IGW, 6 subnets, 2 route tables)
+- [x] Build CrdCluster layer with ALB, security groups, target groups, Fargate cluster
+- [x] Build CrdDb layer (future-state, green dashed) with RDS, DB SG, DB Subnet Group
+- [x] Build CrdService layer (future-state, magenta dashed) with 4 Fargate tasks across 2 AZs
+- [x] Add NAT Gateway in Public Subnet A with `outbound :443` line and updated Private Route Table
+- [x] Add Cross-Stack Exports table in bottom-right, color-coded by stack
+- [x] Label every connection line with its port number (especially `:4567` not `:80` for Service SG)
+- [x] Color-code stacks (CrdNet blue, CrdCluster teal solid, CrdDb green dashed, CrdService magenta dashed)
+- [x] Add CRITICAL callout next to Service SG explaining Fargate AWSVPC-mode requirement
+- [x] Add cross-SG reference lines (`allows:4567`, `allows:5432`) showing complete security chain
+- [x] Resolve TG-vs-SG conceptual confusion (TGs are routing, SGs are firewalls — not nested)
 - [x] Save Lucid diagram URL to project memory
 - [x] Recreate diagram in Mermaid for in-repo journal record
+- [x] Export PNG screenshots and commit to repo
 
-### Carried Forward
-- [ ] Build `CrdDb` stack for RDS PostgreSQL with `DeletionPolicy: Retain` and snapshot-restore from existing `cruddur-db-instance` (Week 12)
-- [ ] Build `CrdService` stack for ECS service definitions (Week 12)
-- [ ] Update `CrdCluster` to publish `CrdClusterServiceSGId` so `CrdDb` can reference it
-- [ ] Send IT policy / SSL inspection bypass clarification request to Antwaun
-- [ ] Rotate IAM Access Key 1 on `C.Fenton_CLI`
-- [ ] Remediate sensitive value flagged in earlier journal entry (`journal/week4.md`)
-- [ ] Harden `.gitignore` with `*.pem`, `*.key`, `__pycache__/` additions
-- [ ] Optional: migrate Route 53 records and the CI/CD pipeline itself into CloudFormation
+---
+
+## Week 12 Work
+
+Substantive engineering work for the next sessions:
+
+- [ ] Update CrdCluster template to add `CrdClusterServiceSG` resource with `TCP 4567 from CrdClusterALBSG` ingress rule, plus `CrdClusterServiceSGId` export
+- [ ] Deploy CrdCluster stack update (single resource addition)
+- [ ] Build CrdDb stack for RDS PostgreSQL
+  - Snapshot-restore from existing `cruddur-db-instance` in default VPC via `DBSnapshotIdentifier`
+  - `DeletionPolicy: Snapshot` and `UpdateReplacePolicy: Snapshot`
+  - `db.t4g.micro` (Graviton ARM, free-tier eligible)
+  - PostgreSQL 16.x (modern engine version)
+  - `PubliclyAccessible: false`
+  - `DeletionProtection: true`
+  - `BackupRetentionPeriod: 7` days
+  - DB Subnet Group across all three private subnets
+  - DB Security Group with `TCP 5432 from CrdClusterServiceSG` (cross-stack reference)
+  - Automated SSM Parameter Store CONNECTION_URL update via deploy script
+- [ ] Build CrdService stack for ECS service definitions
+  - Two services (backend-flask, frontend-react-js)
+  - Two tasks per service across us-east-1a and us-east-1b for HA
+  - Service SG attached to task ENIs
+  - Target group registration to BackendTG (port 4567) and FrontendTG (port 3000)
+- [ ] Optional: migrate Route 53 records into CloudFormation (CrdDns stack)
+- [ ] Optional: migrate CI/CD pipeline itself into CloudFormation (CrdCicd stack)
+
+---
+
+## Security & Hygiene Backlog
+
+Operational/security work tracked but lower priority than the substantive engineering above:
+
+- [ ] **P1:** Rotate RDS master password (was exposed in earlier journal entry on public repo)
+- [ ] **P2:** Rotate IAM Access Key 1 on `C.Fenton_CLI`
+- [ ] **P3:** Clean up Kiro IDE `trustedCommands` (remove `git reset --hard origin/main` and global git config commands)
+- [ ] **P4:** Repo hygiene
+  - Delete `backup/kiro-dev-pre-sync-20260502` branch
+  - Harden `.gitignore` with `*.pem`, `*.key`, `__pycache__/` additions
+- [ ] **P5:** Create `bin/cfn/teardown` script for ordered multi-stack teardown
+- [ ] **External:** Follow up with Antwaun on SSL inspection bypass IT ticket for Docker domains
+
+---
+
+## Closing Thought
+
+A 26-resource multi-stack architecture, deployed end-to-end and torn down clean, with every port mapping and security boundary documented in a portfolio-grade diagram. Week 10 made networking real; Week 11 made compute real *and* made the architecture visible. Week 12 will make data real and start tying the whole thing together as a deployable application.
+
+The shift this week is one I'll keep with me: **infrastructure isn't just code that runs; it's documentation that prevents bugs.** Every label on the diagram, every export in the table, every comment in the YAML is preventing some specific class of mistake. That's what production-grade thinking looks like, and the bootcamp gave me the chance to learn the habit before the cost of not having it becomes severe.

--- a/journal/week11.md
+++ b/journal/week11.md
@@ -1,1 +1,341 @@
 # Week 11 — CloudFormation Part 2
+
+## What I Set Out To Do
+
+Week 10 gave me a working CloudFormation networking stack (`CrdNet`). Week 11 was about three things on top of that:
+
+1. **Refactoring the deploy workflow** to externalize configuration into a TOML file, so my scripts don't hardcode bucket names, regions, or stack names.
+2. **Building the compute layer** — a new `CrdCluster` stack defining my ECS Fargate cluster, the Application Load Balancer, listeners, target groups, and the ALB security group, all consuming the networking exports from `CrdNet`.
+3. **Drawing the network architecture diagram** in Lucid as a portfolio artifact and a debugging insurance policy.
+
+This was the densest week of the bootcamp so far. By the end of it I had two CloudFormation stacks deployed end-to-end, all eight cluster resources running, every connection in my architecture mapped on paper with explicit port labels, and a refactored deploy pipeline that follows the same configuration-externalization pattern used in real production systems.
+
+---
+
+## Session A — `cfn-toml` Refactor
+
+The detailed notes for this session live in **[`week11-session-a.md`](./week11-session-a.md)**, including the specific decisions I made (chose `ruby-apt` over `snap` for predictable system paths; used `--user-install` for cfn-toml to avoid `sudo`; kept `CFN_BUCKET` in `.bashrc` for interactive shell convenience while letting the TOML file own deploy-time config), the verification narrative, and the loose ends carried forward.
+
+Quick summary: I refactored `bin/cfn/networking-deploy` to read `bucket`, `region`, and `stack_name` from `aws/cfn/networking/config.toml` instead of having those values baked into the script. Real values go in `config.toml` (gitignored). A placeholder `config.toml.example` is committed so anyone cloning the repo knows the schema. End-to-end verification confirmed the refactor produces an identical 18-resource, 5-export deploy — same outputs as Week 10, just sourced from a cleaner config layer.
+
+This is the same configuration-externalization pattern I already use for `.env` files in the application code, now applied to infrastructure. Real-world value: the same script can deploy to dev, staging, and prod by pointing at different TOML files, with no script edits.
+
+---
+
+## Session B — Building the `CrdCluster` Stack
+
+### What the Stack Contains
+
+This is the compute layer of the application. The template at `aws/cfn/cluster/template.yaml` is 233 lines and defines:
+
+- An **ECS Fargate cluster** with Container Insights enabled and a Service Connect namespace
+- An **internet-facing Application Load Balancer** deployed across the three public subnets imported from `CrdNet`
+- An **HTTPS listener on port 443** with my ACM certificate for `*.fentoncruddur.com`, default forward to the frontend target group
+- An **HTTP listener on port 80** with a 301 redirect to HTTPS
+- A **listener rule** routing any request with host header `api.fentoncruddur.com` to the backend target group (priority 1)
+- A **backend target group** — port 4567, type `ip` (required for Fargate's `awsvpc` network mode), health check on `/api/health-check`
+- A **frontend target group** — port 3000, type `ip`, health check on `/`
+- An **ALB security group** allowing inbound TCP 443 and TCP 80 from `0.0.0.0/0`
+
+Eight resources total. Five cross-stack outputs (`ClusterName`, `ALBSecurityGroupId`, `HTTPSListenerArn`, `BackendTGArn`, `FrontendTGArn`) that future stacks will consume.
+
+### Cross-Stack Imports — The Whole Point of Layered IaC
+
+`CrdCluster` imports values from `CrdNet` using the `!ImportValue` intrinsic:
+
+```yaml
+Properties:
+  VpcId: !ImportValue CrdNetVpcId
+  Subnets:
+    Fn::Split:
+      - ","
+      - !ImportValue CrdNetPublicSubnetIds
+```
+
+That second pattern is worth pausing on. `CrdNet` exports `CrdNetPublicSubnetIds` as a comma-separated string because CloudFormation exports can only be strings, not lists. The cluster stack needs a list, so I have to split the string back at import time using the long-form `Fn::Split` intrinsic. The short-form `!Split` syntax does not nest cleanly inside `!ImportValue`. This is one of the bugs Andrew Brown specifically called out in his transcripts.
+
+### Three Andrew-Known Bugs I Dodged Up Front
+
+Andrew's transcripts cover three subtle bugs that cost him hours in production. I made a point of dodging all three before deployment:
+
+1. **Security group references for the ALB.** Use `!GetAtt ALBSecurityGroup.GroupId`, not `!Ref ALBSecurityGroup`. With `!Ref` you get the SG's logical name, not the GroupId the ALB resource actually needs, and the deploy fails with a confusing error.
+2. **Subnet selection.** Pass only the three public subnets to the ALB, not all six. Internet-facing ALBs cannot live in private subnets, and passing more than one subnet per AZ produces a uniqueness conflict.
+3. **Long-form intrinsic nesting.** Use `Fn::Split` when nesting inside `!ImportValue`, not the short-form `!Split`.
+
+The fact that none of these surfaced during deploy is the best evidence I had them right.
+
+### One Bug I Did Hit — YAML Indentation
+
+I built the cluster template in five incremental chunks (parameters, resources, intrinsics, outputs, tagging). After chunk three, `cfn-lint` started complaining about an unrecognized property. After staring at the file for a few minutes I caught it — the property was at the wrong indentation level. YAML treats indentation as semantically meaningful, so an extra two spaces had turned a top-level resource property into a nested sub-property of the wrong key.
+
+This is the kind of bug that doesn't exist in JSON (which uses explicit braces) but is a constant hazard in YAML. `cfn-lint` caught it in seconds; otherwise I would have caught it eventually at deploy time at much higher cost. The lesson is that `cfn-lint` is a critical guardrail — every deploy script's first step.
+
+### The `bash -x` Detour
+
+While testing the cluster deploy script for the first time, I accidentally ran `bash -x` against it. `bash -x` traces and executes every line — which meant the script ran end-to-end *without my eyes on it*, including the `aws cloudformation deploy` call. It uploaded the template to S3 and created a change set against a stub `CrdCluster` stack.
+
+Because the script uses `--no-execute-changeset`, **no resources were actually deployed**. The stub stack and its change set were free to clean up:
+
+```bash
+aws cloudformation delete-stack --stack-name CrdCluster
+```
+
+The damage was zero, but the lesson was sharp: **read before you run.** Don't grab a script you're still tuning and pipe it through anything that auto-executes. That's the kind of mistake that, in a real production environment, ends up on a postmortem. I'd rather learn it here on a stub stack than later on a production cluster.
+
+After cleanup, I committed the cluster scaffolding as `6402f77`:
+
+```
+feat(cfn): add cluster stack scaffolding for ECS Fargate + ALB
+```
+
+---
+
+## Session C — End-to-End Deployment of `CrdCluster`
+
+This was the big one. The first true deployment of the cluster stack against a live AWS account.
+
+### Phase 1 — Deploy CrdNet First
+
+The cluster stack imports from `CrdNet`, so the networking stack has to exist in the account before the cluster's `!ImportValue` references can resolve.
+
+```bash
+./bin/cfn/networking-deploy
+```
+
+Reviewed the change set in the Console (18 Add actions, all subnets, RTAs, routes, VPC, IGW). Executed. Stack reached `CREATE_COMPLETE` in about 25 seconds.
+
+### Phase 2 — Deploy CrdCluster
+
+```bash
+./bin/cfn/cluster-deploy
+```
+
+This was the held-breath moment. Reviewed the change set carefully — 8 Add actions for `FargateCluster`, `ALBSecurityGroup`, `ALB`, `HTTPSListener`, `HTTPListener`, `ApiALBListenerRule`, `FrontendTG`, `BackendTG`. Reviewed the Parameters tab to confirm cfn-toml had populated the four expected values (the certificate ARN, the host header for `api.fentoncruddur.com`, the frontend health check path, the backend health check path). Both correct. Executed.
+
+The deploy took about three minutes total. The ALB alone took roughly 75 seconds — AWS provisions it across multiple AZs with health checking and DNS setup, and that orchestration is genuinely slower than spinning up lighter resources. On every future cluster deploy, the ALB will be the bottleneck.
+
+The dependency cascade resolved exactly as expected: `FargateCluster` and `ALBSecurityGroup` first (parallel, no dependencies), then `ALB` (depends on the SG and the public subnets), then the two target groups (depend on the VPC), then the two listeners (depend on the ALB and TGs), then `ApiALBListenerRule` last (depends on the HTTPS listener and the backend TG).
+
+All 8 resources reached `CREATE_COMPLETE`. The Outputs tab populated with the 5 expected exports. Cross-stack imports worked live. No bugs surfaced.
+
+### Phase 3 — Teardown in Reverse Dependency Order
+
+CloudFormation enforces a hard rule: you cannot delete a stack whose exports are still being imported by another stack. So teardown has to mirror deployment order — child stacks first, parent stacks last.
+
+```bash
+# CrdCluster first (ALB deletion is the bottleneck again — ~2 min)
+aws cloudformation delete-stack --stack-name CrdCluster
+
+# Confirm gone before deleting CrdNet
+aws cloudformation describe-stacks --stack-name CrdCluster \
+  --query "Stacks[0].StackStatus" --output text
+# Expected: "Stack with id CrdCluster does not exist"
+
+# Then CrdNet
+aws cloudformation delete-stack --stack-name CrdNet
+```
+
+Both went clean. The "mirror-image dependency reversal" is the pattern that applies to all layered IaC. Deploy bottom-up, tear down top-down. I'll see this same shape on every multi-stack architecture for the rest of my career.
+
+---
+
+## Session D — The Network Architecture Diagram
+
+The last big piece of the week. Andrew Brown explicitly called out in his transcripts that a clear network architecture diagram would have saved him hours of debugging on multiple occasions. The reason is simple: when you can *see* every connection and every port at a glance, certain classes of bug — like accidentally putting a service security group on port 80 when the container is listening on port 4567 — become visually obvious.
+
+I built the diagram in Lucid using a layered AI-prompt approach (one prompt per layer, then iterative cleanup). The Lucid URL is saved to my project memory.
+
+### What the Diagram Shows
+
+External entities on the left: a Client/User, Route 53 (managing both `fentoncruddur.com` and `api.fentoncruddur.com`), and ACM Certificate Manager (issuing the `*.fentoncruddur.com` certificate).
+
+The AWS Cloud boundary on the right contains:
+
+- **CrdNet Stack (blue boundary)** — VPC `10.0.0.0/16`, the Internet Gateway, both route tables, and all six subnets organized into three vertical AZ columns (`us-east-1a/b/c`). Each column has one public subnet stacked above one private subnet.
+- **CrdCluster Stack (orange boundary)** — the ALB, both security groups (ALB and Service), the Fargate cluster, the two target groups.
+- **CrdDb Stack (green dashed boundary)** — RDS in the private subnets, the DB subnet group, the DB security group. Dashed because it's not yet built; that's Week 12.
+
+Every connection line has its port labeled. The most important "insurance policy" labels:
+
+- Client → ALB on `:443` and `:80`
+- ALB → BackendTG → backend task on `:4567` (**not** `:80`)
+- ALB → FrontendTG → frontend task on `:3000`
+- ServiceSG inbound from ALBSG on `:4567` (**not** `:80`) — this is the bug that took Andrew and Bako two debugging sessions to find
+- Backend task → RDS on `:5432`
+
+Every port label is "redundant" in the sense that the same information is available by clicking into AWS Console pages. The redundancy is the point. When the diagram is in front of me during a debugging session, port misalignment is visible at a glance.
+
+### A Mermaid Recreation
+
+For posterity in this journal, here's a Mermaid recreation of the Lucid diagram. It's lower-fidelity (no AWS icons, no perfect AZ columns), but it captures every resource, every cross-stack relationship, and every port label:
+
+```mermaid
+flowchart TB
+    Client["Client / User"]
+    R53["Route 53<br/>fentoncruddur.com<br/>api.fentoncruddur.com"]
+    ACM["ACM Certificate<br/>*.fentoncruddur.com"]
+    Net(("Internet"))
+
+    Client -->|DNS lookup| R53
+    Client -->|HTTPS traffic| Net
+    Net -->|":443 / :80"| IGW
+
+    subgraph VPC["VPC CrdNet — 10.0.0.0/16"]
+        IGW["CrdNetIGW"]
+
+        subgraph PubLayer["Public Layer (route 0.0.0.0/0 → IGW)"]
+            direction LR
+            PubA["Public Subnet A<br/>us-east-1a<br/>10.0.0.0/24"]
+            PubB["Public Subnet B<br/>us-east-1b<br/>10.0.1.0/24"]
+            PubC["Public Subnet C<br/>us-east-1c<br/>10.0.2.0/24"]
+        end
+
+        subgraph Cluster["CrdCluster Stack"]
+            ALBSG["CrdClusterALBSG<br/>in: :443, :80 from 0.0.0.0/0"]
+            ALB["CrdClusterALB<br/>multi-AZ"]
+            FTG["FrontendTG<br/>:3000 | type ip"]
+            BTG["BackendTG<br/>:4567 | type ip"]
+            FargateCluster["CrdClusterFargateCluster<br/>ECS Fargate"]
+            ServiceSG["CrdClusterServiceSG<br/>in: :4567 from ALBSG"]
+        end
+
+        subgraph PrivLayer["Private Layer (route 10.0.0.0/16 → local)"]
+            direction LR
+            PrivA["Private Subnet A<br/>us-east-1a<br/>10.0.4.0/24"]
+            PrivB["Private Subnet B<br/>us-east-1b<br/>10.0.5.0/24"]
+            PrivC["Private Subnet C<br/>us-east-1c<br/>10.0.6.0/24"]
+        end
+
+        subgraph DbStack["CrdDb Stack (future — Week 12)"]
+            DbSG["CrdDbSG<br/>in: :5432 from ServiceSG"]
+            RDS["Amazon RDS<br/>PostgreSQL"]
+        end
+    end
+
+    IGW --> ALB
+    ACM -.->|cert| ALB
+    ALB -->|protected by| ALBSG
+    ALB -->|":3000"| FTG
+    ALB -->|":4567"| BTG
+    FTG --> FargateCluster
+    BTG --> FargateCluster
+    FargateCluster -->|protected by| ServiceSG
+    FargateCluster -.->|":5432"| RDS
+    RDS -.->|protected by| DbSG
+    ALBSG -.->|allows :4567| ServiceSG
+    ServiceSG -.->|allows :5432| DbSG
+
+    classDef netStack fill:#e3f2fd,stroke:#1976d2,stroke-width:2px,color:#000
+    classDef clusterStack fill:#fff3e0,stroke:#f57c00,stroke-width:2px,color:#000
+    classDef dbStack fill:#e8f5e9,stroke:#388e3c,stroke-width:2px,stroke-dasharray:5 5,color:#000
+    classDef external fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px,color:#000
+
+    class IGW,PubA,PubB,PubC,PrivA,PrivB,PrivC netStack
+    class ALB,ALBSG,FTG,BTG,FargateCluster,ServiceSG clusterStack
+    class RDS,DbSG dbStack
+    class Client,R53,ACM,Net external
+```
+
+### Why This Diagram Lives in My Repo
+
+This is portfolio material. When an interviewer asks "walk me through your architecture," I can pull this up and point at every box. When I'm debugging a connectivity issue, I can trace the path from client to container with my finger and check whether each port matches what's deployed. When I add `CrdDb` and `CrdService` in Week 12, I'll convert those dashed boundaries to solid lines and the diagram evolves with the project.
+
+The Lucid version is the canonical one; the Mermaid version above lives in this journal as a permanent record that travels with the codebase.
+
+---
+
+## Cross-Cutting Lessons
+
+### Cost Discipline
+
+Both stacks were deployed, verified, and torn down within the same sessions. The ALB alone costs roughly $0.0225/hour (~$0.55/day) regardless of traffic. The other seven cluster resources are essentially free at rest, but the ALB is enough that I never leave it running between sessions. Every session ends with both stacks gone and `describe-stacks` returning "does not exist."
+
+### The Reproducibility Promise
+
+I proved this week, on a more substantial scale than Week 10, that a 26-resource multi-stack architecture (18 networking + 8 cluster) can be torn down and rebuilt identically in roughly four minutes from two YAML files and two TOML configs. That's the whole point of Infrastructure as Code. Until you see it work, it's abstract. Once you watch it happen, it changes how you think about every piece of infrastructure you'll ever own.
+
+### Read Before You Run
+
+The `bash -x` incident was harmless because of the `--no-execute-changeset` guard, but it taught me something durable: I never want to be in a position where a script auto-executes its way past a step I haven't reviewed. From now on, every new script gets reviewed end-to-end before execution. Every deploy script uses `--no-execute-changeset` by default. Every destructive operation prompts for confirmation.
+
+---
+
+## Commands Reference
+
+```bash
+# Deploy CrdNet (must exist before CrdCluster)
+./bin/cfn/networking-deploy
+
+# Deploy CrdCluster (consumes CrdNet exports)
+./bin/cfn/cluster-deploy
+
+# Teardown in reverse order — CrdCluster first
+aws cloudformation delete-stack --stack-name CrdCluster
+
+# Confirm before tearing down CrdNet
+aws cloudformation describe-stacks --stack-name CrdCluster \
+  --query "Stacks[0].StackStatus" --output text
+
+# Then CrdNet
+aws cloudformation delete-stack --stack-name CrdNet
+
+# Inspect stack outputs
+aws cloudformation describe-stacks --stack-name CrdCluster \
+  --query "Stacks[0].Outputs" --output table
+```
+
+---
+
+## Progress Checklist
+
+### Session A — `cfn-toml` Refactor
+See [`week11-session-a.md`](./week11-session-a.md) for full notes.
+
+- [x] Refactor `bin/cfn/networking-deploy` to read from `aws/cfn/networking/config.toml`
+- [x] Create `config.toml.example` (committed) and `config.toml` (gitignored)
+- [x] End-to-end verification — same 18 resources, same 5 outputs as Week 10 baseline
+
+### Session B — `CrdCluster` Scaffolding
+- [x] Write `aws/cfn/cluster/template.yaml` (233 lines, 8 resources, 5 outputs)
+- [x] Define ECS Fargate cluster with Container Insights and Service Connect namespace
+- [x] Define internet-facing ALB in public subnets imported from `CrdNet`
+- [x] Define HTTPS listener (port 443) with ACM cert and default forward to FrontendTG
+- [x] Define HTTP listener (port 80) with 301 redirect to HTTPS
+- [x] Define listener rule routing `api.fentoncruddur.com` host header to BackendTG (priority 1)
+- [x] Define FrontendTG (port 3000, type `ip`, health check `/`)
+- [x] Define BackendTG (port 4567, type `ip`, health check `/api/health-check`)
+- [x] Define ALBSecurityGroup (allow 443 and 80 from 0.0.0.0/0)
+- [x] Create cfn-toml config files for cluster stack
+- [x] Create `bin/cfn/cluster-deploy` using cfn-toml params v2 pattern
+- [x] Catch and fix YAML indentation bug surfaced by `cfn-lint`
+- [x] Dodge three Andrew-known bugs (SG `!GetAtt`, public-only subnets, long-form intrinsics)
+- [x] Recover from accidental `bash -x` execution; verify zero damage
+- [x] Commit cluster scaffolding as `6402f77`
+
+### Session C — End-to-End Deployment
+- [x] Deploy `CrdNet` (prerequisite for cluster imports)
+- [x] Deploy `CrdCluster` end-to-end — all 8 resources reach CREATE_COMPLETE
+- [x] Verify ALB took ~75 seconds (expected bottleneck)
+- [x] Verify cross-stack imports resolved correctly (`VpcId`, `PublicSubnetIds`)
+- [x] Verify three Andrew-known bugs all dodged (deploy success is the proof)
+- [x] Verify 5 outputs populated in `CrdCluster` Outputs tab
+- [x] Tear down `CrdCluster` first, then `CrdNet` (reverse dependency order)
+- [x] Verify both stacks return "does not exist"
+
+### Session D — Network Architecture Diagram
+- [x] Plan diagram layout (external entities left, AWS Cloud right, AZ columns vertical)
+- [x] Generate diagram via layered Lucid AI prompts
+- [x] Label every connection line with its port number (especially `:4567 not :80` for ServiceSG)
+- [x] Color-code stacks (CrdNet blue, CrdCluster orange, CrdDb green dashed)
+- [x] Save Lucid diagram URL to project memory
+- [x] Recreate diagram in Mermaid for in-repo journal record
+
+### Carried Forward
+- [ ] Build `CrdDb` stack for RDS PostgreSQL with `DeletionPolicy: Retain` and snapshot-restore from existing `cruddur-db-instance` (Week 12)
+- [ ] Build `CrdService` stack for ECS service definitions (Week 12)
+- [ ] Update `CrdCluster` to publish `CrdClusterServiceSGId` so `CrdDb` can reference it
+- [ ] Send IT policy / SSL inspection bypass clarification request to Antwaun
+- [ ] Rotate IAM Access Key 1 on `C.Fenton_CLI`
+- [ ] Remediate sensitive value flagged in earlier journal entry (`journal/week4.md`)
+- [ ] Harden `.gitignore` with `*.pem`, `*.key`, `__pycache__/` additions
+- [ ] Optional: migrate Route 53 records and the CI/CD pipeline itself into CloudFormation

--- a/journal/week11.md
+++ b/journal/week11.md
@@ -279,7 +279,7 @@ graph TB
     BTA -.->|egress to ECR| NAT
 ```
 
-The Lucid version is the canonical one with proper AWS icons and clean spatial flow; this Mermaid version lives in the journal as a permanent record that travels with the codebase and renders in GitHub.
+The [Lucid version](https://lucid.app/lucidchart/0e65b01c-09ab-454a-b812-49867b336cc7/edit?viewport_loc=4694%2C408%2C5880%2C2844%2C0_0&invitationId=inv_b3558d71-dd1e-451d-aba6-123ef84facc7) is the canonical one with proper AWS icons and clean spatial flow; this Mermaid version lives in the journal as a permanent record that travels with the codebase and renders in GitHub.
 
 ---
 


### PR DESCRIPTION
## Summary
   Adds CrdClusterServiceSG resource to the CrdCluster CFN template, completing the SG chain for upcoming CrdDb and CrdService stacks.

   ## Design
   - Ingress TCP 4567 from ALB SG (backend container port)
   - Ingress TCP 3000 from ALB SG (frontend container port)
   - Sourced by SG ID, not CIDR — defense-in-depth
   - Description encodes Fargate AWSVPC-mode port-mismatch warning in the rule itself

   ## Verification
   - Deployed end-to-end against CrdNet, 9 resources confirmed
   - ServiceSG inbound rules visible in EC2 Console with correct ports + source
   - New export `CrdClusterServiceSGId` published — required input for CrdDb and CrdService next sessions
   - Stacks torn down post-verification for cost discipline

   ## Out of scope (next sessions)
   - CrdDb (RDS snapshot-restore into CrdNet)
   - CrdService (ECS services across 2 AZs)